### PR TITLE
feat: Add support for Pub/Sub attributes

### DIFF
--- a/template.js
+++ b/template.js
@@ -16,6 +16,7 @@ const traceId = isLoggingEnabled ? getRequestHeader('trace-id') : undefined;
 let publishUrl = 'https://pubsub.googleapis.com/v1/projects/'+enc(data.project)+'/topics/'+enc(data.topic)+':publish';
 let method = 'POST';
 let input = data.addEventData ? getAllEventData() : {};
+let attributes = {};
 
 if (data.addTimestamp) input[data.timestampFieldName] = getTimestampMillis();
 if (data.customDataList) {
@@ -41,7 +42,32 @@ if (data.customDataList) {
     });
 }
 
-input = {'messages': [{'data': toBase64(JSON.stringify(input))}]};
+if (data.attributesDataList) {
+    data.attributesDataList.forEach((d) => {
+        if (data.skipNilValues) {
+            const dType = getType(d.value);
+            if (dType === 'undefined' || dType === 'null') return;
+        } else {
+            attributes[d.name] = d.value;
+        }
+    });
+}
+
+
+// Only send `data` and `attributes` keys if their inputs are not empty objects
+let message = {};
+
+if (input && JSON.stringify(input) !== '{}') {
+    message.data = toBase64(JSON.stringify(input));
+}
+
+if (attributes && JSON.stringify(attributes) !== '{}') {
+    message.attributes = attributes;
+}
+
+input = { messages: [message] };
+
+
 
 if (isLoggingEnabled) {
     logToConsole(


### PR DESCRIPTION
Closes #1 

Adds support for Pub/Sub attributes. This allows subscriptions to filter the messages received.

I have avoided any extra imports to reduce any extra overhead. Alternatively `Object` could be required to slightly simplify the checking for empty objects.

I have also extended the `skipNilValues` parameter to also apply to attributes. This is noted in the updated help text in `template.tlp`.

I have confirmed that these changes work as expected in my tag manager container.